### PR TITLE
batch-run all 24 slides, convert notebooks to .py

### DIFF
--- a/manual_annotation/01_clustering.py
+++ b/manual_annotation/01_clustering.py
@@ -1,0 +1,201 @@
+import pandas as pd
+import importlib
+from pathlib import Path
+import numpy as np
+import random
+import anndata as ad
+from IPython.core.interactiveshell import InteractiveShell
+from clustering import subcluster
+import re
+import sys
+
+import json
+from pathlib import Path
+import geopandas as gpd
+import glob
+
+importlib.reload(subcluster)
+
+if True:
+    from clustering.subcluster import (
+        ClusteringResultManager,
+        plot_clustering_heatmap_2,
+        run_clustering,
+        update_geojson_from_clustering_result,
+    )
+
+InteractiveShell.ast_node_interactivity = "all"
+
+random.seed(0)
+np.random.seed(0)
+
+markers_all = [
+    "CD3",
+    "CD15",
+    "CD8",
+    "CD20",
+    "CD11c",
+    "CD68",
+    "FoxP3",
+    "Pax5",
+    "CD31",
+    "Cytokeratin",
+]
+
+# Get slide number from command-line arguments
+slide_index = int(sys.argv[1])  # e.g., 1, 2, ..., 24
+slide_filename = f"slide_{slide_index:02d}_adata.h5ad"
+
+input_dir = Path("/registered_report/input/h5ad")
+output_root = Path("/registered_report/output")
+
+h5ad_path = input_dir / slide_filename
+
+if not h5ad_path.exists():
+    print(f"File {h5ad_path} not found. Exiting.")
+    sys.exit(1)
+
+slide_name = h5ad_path.stem  # e.g., slide_01_adata
+print(f"Processing {slide_name}")
+
+adata = ad.read_h5ad(h5ad_path)
+
+output_dir = output_root / f"{slide_name}_k=200"
+output_dir.mkdir(parents=True, exist_ok=True)
+
+present_markers = [m for m in markers_all if m in adata.var_names]
+missing_markers = [m for m in markers_all if m not in adata.var_names]
+if missing_markers:
+    print(f"Warning: markers not found and will be skipped: {missing_markers}")
+if not present_markers:
+    print("Error: none of the requested markers were found in adata.var_names. Exiting.")
+    sys.exit(1)
+
+features = present_markers
+unit_ids = adata.obs.index
+manager = ClusteringResultManager(output_dir=output_dir, unit_ids=unit_ids)
+
+# Run clustering
+clustering_result = run_clustering(
+    adata,
+    unit_ids,
+    features,
+    method="phenograph",
+    method_params={"k": 200, "n_jobs": 8},
+    output_dir=output_dir,
+)
+
+unit_ids = np.unique(clustering_result.unit_ids)
+matches = np.array(["_".join(s.split("_")[:2]) for s in unit_ids])
+matches = np.unique(matches)
+
+for unit_id_prefix in matches:
+    n_match = len(
+        [
+            unit_id
+            for unit_id in clustering_result.unit_ids
+            if unit_id.startswith(unit_id_prefix)
+        ]
+    )
+    if n_match > 0:
+        print(f"Found {n_match} units starting with {unit_id_prefix} in this clustering")
+    else:
+        print(f"No unit found starting with '{unit_id_prefix} in this clustering")
+
+heatmap_raw = plot_clustering_heatmap_2(
+    adata,
+    clustering_result,
+    features,
+    col_cellsize="cellSize",
+    figsize=(20, 8),
+    col_gap=30,
+    legend_hpad=60,
+)
+heatmap_raw.savefig(f"{output_dir}/heatmap_{slide_name}_dual_raw.png", dpi=300, bbox_inches="tight")
+
+
+non_col_cluster = {"col_cluster": False, "col_dendrogram": False}
+heatmap_vmin_vmax = plot_clustering_heatmap_2(
+    adata,
+    clustering_result,
+    features,
+    col_cellsize="cellSize",
+    figsize=(30, 8),
+    col_gap=30,
+    legend_hpad=60,
+    kwargs_zscore={"vmin": -3, "center": 0, "vmax": 3} | non_col_cluster,
+    kwargs_mean={"vmin": 0, "vmax": 0.5} | non_col_cluster,
+)
+heatmap_vmin_vmax.savefig(f"{output_dir}/heatmap_{slide_name}_dual_vmin_vmax.png", dpi=300, bbox_inches="tight")
+
+for prefix in matches:
+    print(f"/registered_report/input/geojson/{prefix}.geojson")
+    geojson_file = Path(
+        f"/registered_report/input/geojson/{prefix}.geojson"
+    )
+    update_geojson_from_clustering_result(
+        geojson_file,
+        clustering_result,
+        output_dir,
+        unit_id_prefix=f"{prefix}_",
+    )
+
+    matches = glob.glob(f"{output_dir}/geojson/*/{prefix}.geojson")
+    if not matches:
+        raise FileNotFoundError(f"No geojson found for prefix {prefix}")
+
+    in_path = matches[0]
+    gdf = gpd.read_file(in_path)
+    out_dir = Path(f"/registered_report/output/{slide_name}_k=200/per_class_geojson")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+
+    def to_class_dict(val):
+        if isinstance(val, dict):
+            return val
+        if isinstance(val, str):
+            val = val.strip()
+            if val.startswith("{"):
+                try:
+                    return json.loads(val)
+                except json.JSONDecodeError:
+                    pass
+        return None  # unparseable / missing
+
+    gdf["classification_dict"] = gdf["classification"].apply(to_class_dict)
+
+    # Drop rows without a valid classification dict
+    gdf = gdf[gdf["classification_dict"].notna()].copy()
+
+    # Normalize fields for grouping
+    def to_key(d):
+        # d like {"name": "11", "color": [242, 72, 72]}
+        name = str(d.get("name", "unknown"))
+        color = tuple(d.get("color") or [])  # make hashable
+        return (name, color)
+
+    gdf["class_key"] = gdf["classification_dict"].apply(to_key)
+
+    # --- group & write ---
+    summary = []
+    for (name, color), sub in gdf.groupby("class_key"):
+        # build a safe filename: e.g., name-11_color-242-72-72.geojson
+        color_str = "-".join(map(str, color)) if color else "none"
+        fname = f"name-{name}_color-{color_str}_prefix-{prefix}.geojson"
+        out_path = out_dir / fname
+
+        # write just these features
+        sub.drop(columns=[c for c in ["classification_dict", "class_key"] if c in sub.columns]) \
+        .to_file(out_path, driver="GeoJSON")
+
+        summary.append((name, color, len(sub), str(out_path)))
+
+    # --- print summary ---
+    print("Written files:")
+    for name, color, n, p in summary:
+        print(f"  name={name:>4}  color={list(color)}  count={n:>6}  -> {p}")
+
+# Stash result
+clustering_result.stash(output_dir=output_dir)
+
+print(f"Finished: {slide_name}\n")

--- a/manual_annotation/01_submit_clustering.slurm
+++ b/manual_annotation/01_submit_clustering.slurm
@@ -1,0 +1,16 @@
+#!/bin/bash
+#SBATCH --job-name=clustering
+#SBATCH --partition=batch_gpu
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --output=output_%A_%a.log
+#SBATCH --error=error_%A_%a.log
+#SBATCH --gres=gpu:1
+#SBATCH --time=03:00:00
+#SBATCH --array=1-24
+
+ml Miniforge3
+conda activate clustering_3.11
+
+python ./01_clustering.py ${SLURM_ARRAY_TASK_ID}

--- a/manual_annotation/02_annotation.py
+++ b/manual_annotation/02_annotation.py
@@ -1,0 +1,209 @@
+import pandas as pd
+import importlib
+from pathlib import Path
+import numpy as np
+import random
+import anndata as ad
+import json
+import re
+import sys
+
+from clustering import subcluster
+importlib.reload(subcluster)
+
+from clustering.subcluster import (
+    ClusteringResult,
+    ClusteringResultManager,
+    plot_clustering_heatmap_2,
+)
+
+# Set seeds for reproducibility
+random.seed(0)
+np.random.seed(0)
+
+markers_all = [
+    "CD3",
+    "CD15",
+    "CD8",
+    "CD20",
+    "CD11c",
+    "CD68",
+    "FoxP3",
+    "Pax5",
+    "CD31",
+    "Cytokeratin",
+]
+
+def reduce_annotation_for_category(label: str) -> str:
+    if label == "Unknown":
+        return "Unknown"
+    if "and" in label:
+    #if "and" in label or label == "T cells":
+        return "Mixed"
+    return label  # keep actual annotation name (e.g. "B cells", "Tregs", etc.)
+
+
+# Paths
+annotation_json_path = Path("/registered_report/cluster_annotations.json")
+output_root = Path("/registered_report/output")
+input_dir = Path("/registered_report/input/h5ad")
+
+# Load annotations
+with open(annotation_json_path) as f:
+    annotations_all = json.load(f)
+
+for slide, cluster_dict in annotations_all.items():
+    for k in list(cluster_dict.keys()):
+        if cluster_dict[k] == "Artifacts":
+            annotations_all[slide][k] = ""
+
+per_slide_annotation_counts = {}
+# Process each slide in annotations
+for slide_key, annotations in annotations_all.items():
+    print(f"Processing {slide_key}...")
+    print(annotations)
+    print(slide_key)
+
+    slide_number = str(int(slide_key.split("_")[1]))  # '01' -> '1'
+
+    # Setup paths
+    slide_filename = f"{slide_key}_adata.h5ad"
+    h5ad_path = input_dir / slide_filename
+    output_dir = output_root / f"{slide_key}_adata_k=200"
+
+    if not h5ad_path.exists():
+        print(f"H5AD file {h5ad_path} not found. Skipping.")
+        continue
+
+    # Load data
+    adata = ad.read_h5ad(h5ad_path)
+    # derive features from the fixed list, intersected with adata
+    present_markers = [m for m in markers_all if m in adata.var_names]
+    missing_markers = [m for m in markers_all if m not in adata.var_names]
+    if missing_markers:
+        print(f"Warning for {slide_key}: markers not found and skipped: {missing_markers}")
+    if not present_markers:
+        print(f"No requested markers present in {slide_key}; skipping.")
+        continue
+
+    features = present_markers
+
+    # Determine clustering_id by checking geojson folder
+    geojson_dir = output_dir / "geojson"
+    clustering_id = None
+
+    if geojson_dir.is_dir():
+        clustering_dirs = [d for d in geojson_dir.iterdir() if d.is_dir()]
+        if clustering_dirs:
+            newest_dir = max(clustering_dirs, key=lambda d: d.stat().st_mtime)
+            clustering_id = newest_dir.name
+
+    if not clustering_id:
+        print(f"No clustering ID folder found in {geojson_dir}, skipping.")
+        continue
+
+
+    # Load clustering result
+    clustering_result = ClusteringResult.pop(
+        clustering_id=clustering_id,
+        output_dir=output_dir
+    )
+
+    df = clustering_result.cluster_df
+    print("Empty cluster_ids:", df["cluster_ids"].isna().sum())
+    print("Blank string cluster_ids:", (df["cluster_ids"] == "").sum())
+    print("Cluster ID counts:\n", df["cluster_ids"].value_counts(dropna=False))
+
+    print("Unique cluster IDs in result:")
+    print(sorted(clustering_result.cluster_df["cluster_ids"].unique()))
+    print("Type of one cluster ID:", type(clustering_result.cluster_df["cluster_ids"].iloc[0]))
+
+    print("Keys in annotations:", list(annotations.keys()))
+    print("Types in annotations:", {type(k) for k in annotations.keys()})
+
+    # Normalize both to clean string keys
+    cluster_ids = clustering_result.cluster_df["cluster_ids"].astype(str).str.strip().unique()
+    normalized_annotations = {str(k).strip(): v for k, v in annotations.items()}
+
+    # Check coverage
+    missing = set(cluster_ids) - set(normalized_annotations)
+    if missing:
+        print(f"Missing annotations for cluster IDs: {missing}")
+
+
+    print("N clusters in result:", clustering_result.cluster_df["cluster_ids"].nunique())
+    print("N unique annotations passed:", len(annotations))
+
+    # Apply annotation
+    clustering_result.add_annotation(normalized_annotations)
+
+    non_col_cluster = {"col_cluster": False, "col_dendrogram": False}
+    heatmap_full_annotations = plot_clustering_heatmap_2(
+        adata,
+        clustering_result,
+        features,
+        figsize=(30, 8),
+        x_label="tag",
+        col_cellsize="cellSize",
+        col_gap=30,
+        legend_hpad=60,
+        kwargs_zscore={"vmin": -3, "center": 0, "vmax": 3} | non_col_cluster,
+        kwargs_mean={"vmin": 0, "vmax": 0.5} | non_col_cluster,
+    )
+    heatmap_full_annotations.savefig(output_dir / f"heatmap_{slide_filename}_full_annotations.png", dpi=300, bbox_inches="tight")
+
+    # Save result
+    clustering_result.save(output_dir)
+
+    # Create summary manager and filtered result
+    manager = ClusteringResultManager(output_dir=output_dir, unit_ids=adata.obs.index)
+    print(f"Unannotated units: {len(manager.non_explicit_df)}")
+    print(manager.summary_df.annotation.value_counts())
+
+    # Add per-annotation breakdown (excluding unannotated)
+    annotation_counts_clean = manager.summary_df.annotation[manager.summary_df.annotation != ""].value_counts()
+
+    # Normalize to string for consistent JSON keys (optional)
+    annotation_breakdown = {k: int(v) for k, v in annotation_counts_clean.items()}
+
+    per_slide_annotation_counts[slide_key] = annotation_breakdown
+
+    reduced_annotation_counts = {}
+
+    for slide, counts in per_slide_annotation_counts.items():
+        reduced = {}
+        for label, count in counts.items():
+            reduced_label = reduce_annotation_for_category(label)
+            if reduced_label == "":  # ignore empty/unannotated
+                continue
+            reduced[reduced_label] = reduced.get(reduced_label, 0) + count
+        reduced_annotation_counts[slide] = reduced
+
+    idx_annotated = manager.summary_df.annotation != ""
+    result = ClusteringResult(
+        clustering_id="annotated_summary",
+        method="manual_annot",
+        unit_ids=manager.summary_df.index[idx_annotated],
+        cluster_ids=manager.summary_df.annotation[idx_annotated],
+    )
+
+    # Plot heatmap of combined annotations
+    heatmap_combined_annotations = plot_clustering_heatmap_2(
+        adata,
+        result,
+        features,
+        figsize=(20, 8),
+        col_cellsize="cellSize",
+        x_label="annotation",
+        kwargs_zscore={"vmin": -3, "center": 0, "vmax": 3} | non_col_cluster,
+        kwargs_mean={"vmin": 0, "vmax": 0.5} | non_col_cluster,
+    )
+    heatmap_combined_annotations.savefig(output_dir / f"heatmap_{slide_filename}_combined_annotations.png", dpi=300, bbox_inches="tight")
+
+    # Full annotation
+
+    heatmap_full_annotations.savefig(output_dir / f"heatmap_{slide_filename}_full_annotations.svg", bbox_inches="tight")
+
+    heatmap_combined_annotations.savefig(output_dir / f"heatmap_{slide_filename}_combined_annotations.svg", bbox_inches="tight")
+
+print("Done.")

--- a/manual_annotation/02_submit_annotation.slurm
+++ b/manual_annotation/02_submit_annotation.slurm
@@ -1,0 +1,14 @@
+#!/bin/bash
+#SBATCH --job-name=annotation
+#SBATCH --partition=batch_cpu
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=8G
+#SBATCH --output=output_%A_%a.log
+#SBATCH --error=error_%A_%a.log
+#SBATCH --time=03:00:00
+
+ml Miniforge3
+conda activate clustering_3.11
+
+python ./02_annotation.py

--- a/manual_annotation/03_phenotype_map.py
+++ b/manual_annotation/03_phenotype_map.py
@@ -1,0 +1,210 @@
+import os
+import sys
+import argparse
+import glob
+import numpy as np
+import tifffile
+import matplotlib.pyplot as plt
+from matplotlib.patches import Patch
+from tqdm import tqdm
+import pandas as pd
+import matplotlib.colors as mcolors
+
+# --- Palette (exactly the same as your preferred one) ---
+CELLTYPE_COLOR = {
+    # T-cell family
+    "T cells": "#E41A1C",          # Set1 red
+    "CD8+ T cells": "#FB6A4A",     # custom salmon
+    "CD8- T cells": "#FCBBA1",     # lighter salmon
+    "Tregs": "#FEB24C",            # orange
+
+    # Other lineages (Set1)
+    "B cells": "#377EB8",          # Set1 blue
+    "Epithelial": "#984EA3",       # Set1 purple
+    "Epithelial and B cells": "#4DAF4A",  # Set1 green
+    "Macrophages": "#A65628",      # Set1 brown
+    "Neutrophils and Unknown": "#F781BF", # Set1 pink
+
+    "Unknown": "#525252",          # dark gray
+}
+
+MIXED_COLOR = "#bdbdbd"  # default/fallback color
+
+# include Mixed explicitly so it shows in the legend
+PALETTE = {**CELLTYPE_COLOR, "Mixed": MIXED_COLOR}
+
+celltype_colors_rgb = {ct: mcolors.to_rgb(hx) for ct, hx in PALETTE.items()}
+legend_elements = [Patch(facecolor=col, label=ct, edgecolor="black")
+                   for ct, col in celltype_colors_rgb.items()]
+
+BASE = "/registered_report"
+
+def pad_slide(slide_num: int) -> str:
+    if not (1 <= slide_num <= 24):
+        raise ValueError(f"Slide must be in 1..24, got {slide_num}")
+    return f"{slide_num:02d}"
+
+def clustering_csv(slide_str: str) -> str:
+    """Return the first CSV found for this slide's clustering results (zero-padded path)."""
+    pattern = os.path.join(BASE, f"output/slide_{slide_str}_adata_k=200/clustering_results/*.csv")
+    files = sorted(glob.glob(pattern))
+    if not files:
+        raise FileNotFoundError(f"No CSV found matching: {pattern}")
+    return files[0]
+
+def output_dir(slide_str: str) -> str:
+    d = os.path.join(BASE, f"output/slide_{slide_str}_adata_k=200")
+    os.makedirs(d, exist_ok=True)
+    return d
+
+def fov_paths(slide_str: str, fov: int):
+    """
+    MESMER filenames use *un-padded* slide numbers.
+    Convert slide_str ('07') -> '7' for overlay/mask file names.
+    """
+    slide_unpadded = str(int(slide_str))
+    outline = os.path.join(BASE, f"MESMER_overlay/overlay_{slide_unpadded}_FOV{fov}.tiff")
+    seg     = os.path.join(BASE, f"MESMER_mask/segmentation_mask_{slide_unpadded}_FOV{fov}.tiff")
+    return outline, seg
+
+def verify_all_files_present(slide_str: str) -> bool:
+    """Check that both FOV1 and FOV2 overlay+seg files exist. If any missing, print and return False."""
+    missing = []
+    for fov in (1, 2):
+        outline, seg = fov_paths(slide_str, fov)
+        if not os.path.exists(outline):
+            missing.append(outline)
+        if not os.path.exists(seg):
+            missing.append(seg)
+    if missing:
+        print(f"For slide {slide_str}, the following required file(s) are missing:")
+        for m in missing:
+            print(f"   - {m}")
+        print("Skipping this slide.")
+        return False
+    return True
+
+def process_single_core(slide_str: str, core_id: str, annotation_df: pd.DataFrame, out_dir: str):
+    """Render a colored segmentation for a single core and save PNG."""
+    try:
+        fov = 1 if core_id.endswith("_1") else 2
+        outline_path, seg_path = fov_paths(slide_str, fov)
+
+        seg = tifffile.imread(seg_path).astype(np.int64)
+        outline = tifffile.imread(outline_path)[..., 0]
+        outline_mask = (outline == 1)
+
+        core_ann = annotation_df[annotation_df["core"] == core_id].copy()
+        core_ann["cell_label"] = pd.to_numeric(core_ann["cell_label"], errors="coerce").astype("Int64")
+        core_ann = core_ann.dropna(subset=["cell_label"]).astype({"cell_label": np.int64})
+
+        label_to_type = core_ann.set_index("cell_label")["annotation"].to_dict()
+
+        max_label = int(seg.max()) if seg.size else 0
+        color_map = np.zeros((max_label + 1, 3), dtype=np.float32)
+
+        present_labels = np.unique(seg[seg > 0])
+        for lab in present_labels:
+            ct = label_to_type.get(int(lab), None)
+
+            # normalize/clean the annotation string
+            if isinstance(ct, str):
+                ct = ct.strip()
+            # default to Mixed if missing/empty or not in our palette
+            if not ct or ct not in celltype_colors_rgb:
+                ct = "Mixed"
+
+            color_map[lab] = celltype_colors_rgb.get(ct, mcolors.to_rgb(MIXED_COLOR))
+
+        colored = color_map[seg]
+        colored[outline_mask] = (0, 0, 0)  # white outline
+
+        plt.figure(figsize=(20, 20), facecolor="white")
+        plt.imshow(colored)
+        plt.axis("off")
+        plt.legend(
+            handles=legend_elements,
+            loc="center left",
+            bbox_to_anchor=(1, 0.5),
+            frameon=False,
+            fontsize=14,
+            labelcolor="white",
+            prop={"weight": "bold"},
+        )
+        out_png = os.path.join(out_dir, f"{core_id}.png")
+        out_svg = os.path.join(out_dir, f"{core_id}.svg")
+        plt.savefig(out_png, bbox_inches="tight", dpi=200, facecolor="black", pad_inches=0)
+        plt.savefig(out_svg, bbox_inches="tight", facecolor="black", pad_inches=0)
+        plt.close()
+        print(f"Saved: {out_png}")
+
+    except Exception as e:
+        print(f"Failed for {core_id}: {e}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Render phenotype maps per slide.")
+    parser.add_argument("--slide", type=int, default=None, help="Slide number 1–24 (zero-padded internally).")
+    args = parser.parse_args()
+
+    # Resolve slide number (arg > SLURM_ARRAY_TASK_ID)
+    slide_num = args.slide
+    if slide_num is None:
+        env_id = os.getenv("SLURM_ARRAY_TASK_ID")
+        if env_id is None:
+            print("Provide --slide or run via SLURM array with SLURM_ARRAY_TASK_ID.")
+            sys.exit(1)
+        slide_num = int(env_id)
+
+    slide_str = pad_slide(slide_num)
+
+    # Check inputs first; if anything missing, exit early
+    if not verify_all_files_present(slide_str):
+        return
+
+    try:
+        csv_path = clustering_csv(slide_str)
+    except FileNotFoundError as e:
+        print(f"For slide {slide_str}, {e}")
+        return
+
+    print(f"Using annotations: {csv_path}")
+    out_dir = output_dir(slide_str)
+
+    # Load and filter annotations for this slide only (both cores)
+    # Support both '07_1_' and '7_1_' unit_ids
+    ann = pd.read_csv(csv_path, usecols=["unit_ids", "cluster_ids", "annotation"])
+    slide_unpadded = str(int(slide_str))
+    prefixes = (
+        f"{slide_str}_1_", f"{slide_str}_2_",
+        f"{slide_unpadded}_1_", f"{slide_unpadded}_2_"
+    )
+    ann = ann[ann["unit_ids"].str.startswith(prefixes)].copy()
+
+    if ann.empty:
+        print(f"No matching unit_ids for slide {slide_str} "
+              f"(expected prefixes {', '.join(repr(p) for p in prefixes)}).")
+        return
+
+    parts = ann["unit_ids"].str.split("_")
+    ann["core"] = parts.str[0] + "_" + parts.str[1]
+    ann["cell_label"] = parts.str[-1]
+
+    candidate_cores = set(ann["core"].unique())
+    cores_to_run = []
+    for fov in (1, 2):
+        padded = f"{slide_str}_{fov}"
+        unpadded = f"{slide_unpadded}_{fov}"
+        if padded in candidate_cores:
+            cores_to_run.append(padded)
+        elif unpadded in candidate_cores:
+            cores_to_run.append(unpadded)
+        else:
+            print(f"No annotations for core {padded} or {unpadded}; skipping.")
+
+    for core_id in tqdm(cores_to_run, desc=f"Rendering slide {slide_str}"):
+        process_single_core(slide_str, core_id, ann, out_dir)
+
+    print(f"\nDone with slide {slide_str}. Outputs in: {out_dir}")
+
+if __name__ == "__main__":
+    main()

--- a/manual_annotation/03_submit_phenotype_map.slurm
+++ b/manual_annotation/03_submit_phenotype_map.slurm
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH --job-name=rr_array
+#SBATCH --partition=batch_gpu
+#SBATCH --array=1-24
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --gres=gpu:1
+#SBATCH --mem=8G
+#SBATCH --output=output_%A_%a.log
+#SBATCH --error=error_%A_%a.log
+#SBATCH --time=03:00:00
+
+ml Miniforge3
+conda activate clustering_3.11
+
+# The script will read SLURM_ARRAY_TASK_ID and zero-pad it to 01–24
+python ./03_phenotype_map.py

--- a/manual_annotation/04_stacked_bar_plots.py
+++ b/manual_annotation/04_stacked_bar_plots.py
@@ -1,0 +1,150 @@
+import json
+from pathlib import Path
+import pandas as pd
+import anndata as ad
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import importlib
+from clustering import subcluster
+importlib.reload(subcluster)
+from clustering.subcluster import ClusteringResult, ClusteringResultManager
+
+CELLTYPE_COLOR = {
+    # T-cell family
+    "T cells": "#E41A1C",          # Set1 red
+    "CD8+ T cells": "#FB6A4A",     # custom salmon
+    "CD8- T cells": "#FCBBA1",     # lighter salmon
+    "Tregs": "#FEB24C",            # orange
+
+    # Other lineages (Set1)
+    "B cells": "#377EB8",          # Set1 blue
+    "Epithelial": "#984EA3",       # Set1 purple
+    "Epithelial and B cells": "#4DAF4A",  # Set1 green
+    "Macrophages": "#A65628",      # Set1 brown
+    "Neutrophils and Unknown": "#F781BF", # Set1 pink
+
+    "Unknown": "#525252",          # dark gray
+}
+
+MIXED_COLOR = "#bdbdbd"  # light gray for Mixed
+
+annotation_json_path = Path(
+    "/registered_report/cluster_annotations.json"
+)
+output_root = Path("/registered_report/output")
+input_dir = Path("/registered_report/input/h5ad")
+
+# Slides visual order (conditions)
+custom_order = [
+    "BIDMC_13", "BIDMC_21", "BIDMC_5", "BIDMC_15", "BIDMC_23", "BIDMC_17",
+    "BIDMC_24", "BIDMC_8", "BIDMC_7", "BIDMC_9", "BIDMC_22", "BIDMC_16",
+    "BIDMC_14", "BIDMC_19", "BIDMC_1", "BIDMC_2", "BIDMC_6", "BIDMC_20",
+    "BIDMC_3", "BIDMC_18", "BIDMC_4", "BIDMC_12", "BIDMC_11", "BIDMC_10"
+]
+slide_to_condition = {f"slide_{int(b.split('_')[1]):02d}": b for b in custom_order}
+condition_to_slide = {v: k for k, v in slide_to_condition.items()}
+
+def reduce_annotation_for_category(label: str) -> str:
+    if label == "Unknown":
+        return "Unknown"
+    if label in CELLTYPE_COLOR:
+        return label
+    return "Mixed"
+
+#remove Artifacts from plotting
+with open(annotation_json_path) as f:
+    annotations_all = json.load(f)
+for slide, cluster_dict in annotations_all.items():
+    for k in list(cluster_dict.keys()):
+        if cluster_dict[k] == "Artifacts":
+            annotations_all[slide][k] = ""
+
+per_slide_annotation_counts: dict[str, dict[str, int]] = {}
+
+for slide_key, annotations in annotations_all.items():
+    slide_filename = f"{slide_key}_adata.h5ad"
+    h5ad_path = input_dir / slide_filename
+    output_dir = output_root / f"{slide_key}_adata_k=200"
+    geojson_dir = output_dir / "geojson"
+    if not h5ad_path.exists() or not geojson_dir.is_dir():
+        continue
+
+    # pick newest clustering id
+    clustering_dirs = [d for d in geojson_dir.iterdir() if d.is_dir()]
+    if not clustering_dirs:
+        continue
+    clustering_id = max(clustering_dirs, key=lambda d: d.stat().st_mtime).name
+
+    # load clustering result & apply annotations
+    clustering_result = ClusteringResult.pop(clustering_id=clustering_id, output_dir=output_dir)
+    df = clustering_result.cluster_df
+    normalized_annotations = {str(k).strip(): v for k, v in annotations.items()}
+    clustering_result.add_annotation(normalized_annotations)
+    clustering_result.save(output_dir)
+
+    # manager for summary
+    adata = ad.read_h5ad(h5ad_path)
+    manager = ClusteringResultManager(output_dir=output_dir, unit_ids=adata.obs.index)
+
+    # count non-empty annotations
+    counts = manager.summary_df.annotation[manager.summary_df.annotation != ""].value_counts()
+    per_slide_annotation_counts[slide_key] = {k: int(v) for k, v in counts.items()}
+
+# reduce to actual labels + mixed + unknown
+reduced_annotation_counts: dict[str, dict[str, int]] = {}
+for slide, counts in per_slide_annotation_counts.items():
+    agg: dict[str, int] = {}
+    for label, cnt in counts.items():
+        r = reduce_annotation_for_category(label)
+        if r == "":
+            continue
+        agg[r] = agg.get(r, 0) + int(cnt)
+    reduced_annotation_counts[slide] = agg
+
+reduced_df = pd.DataFrame(reduced_annotation_counts).T.fillna(0)
+reduced_df_frac = reduced_df.div(reduced_df.sum(axis=1), axis=0).fillna(0)
+
+# slide order by condition, keeping only present
+ordered_slide_ids = [
+    condition_to_slide[c] for c in custom_order
+    if c in condition_to_slide and condition_to_slide[c] in reduced_df_frac.index
+]
+reduced_df_frac = reduced_df_frac.loc[ordered_slide_ids]
+
+# label order
+defined_order = [lab for lab in CELLTYPE_COLOR.keys()
+                 if lab in reduced_df_frac.columns and lab != "Unknown"]
+
+tail = [lab for lab in ["Mixed", "Unknown"] if lab in reduced_df_frac.columns]
+label_list = defined_order + tail
+
+reduced_df_frac = reduced_df_frac.reindex(columns=label_list, fill_value=0)
+-
+label_color_map = {
+    **{lab: mcolors.to_rgb(CELLTYPE_COLOR[lab]) for lab in defined_order},
+    "Mixed": mcolors.to_rgb(MIXED_COLOR),
+    "Unknown": mcolors.to_rgb(CELLTYPE_COLOR["Unknown"]),
+}
+color_list = [label_color_map[l] for l in label_list]
+
+ax = reduced_df_frac.plot(
+    kind="bar",
+    stacked=True,
+    figsize=(18, 8),
+    color=color_list,
+    edgecolor="black",
+    linewidth=0.4,
+)
+plt.ylabel("Fraction of annotated cells")
+plt.title("Annotation Breakdown: Actual Labels vs Mixed vs Unknown (per slide)")
+plt.xticks(rotation=90)
+plt.ylim(0, 1.0)
+plt.legend(
+    title="Annotation",
+    bbox_to_anchor=(1.02, 1),
+    loc="upper left",
+    fontsize="small",
+)
+plt.tight_layout()
+plt.savefig(output_root / "annotation_mixed_vs_single_vs_unknown.svg", bbox_inches="tight")
+plt.close()

--- a/manual_annotation/04_submit_stacked_bar_plot.slurm
+++ b/manual_annotation/04_submit_stacked_bar_plot.slurm
@@ -1,0 +1,14 @@
+#!/bin/bash
+#SBATCH --job-name=figure1
+#SBATCH --partition=batch_cpu
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=8G
+#SBATCH --output=output_%A_%a.log
+#SBATCH --error=error_%A_%a.log
+#SBATCH --time=03:00:00
+
+ml Miniforge3
+conda activate clustering_3.11
+
+python ./04_stacked_bar_plots.py

--- a/manual_annotation/05_enrichment_plots.py
+++ b/manual_annotation/05_enrichment_plots.py
@@ -1,0 +1,216 @@
+import json
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import anndata as ad
+import matplotlib.pyplot as plt
+from matplotlib.patches import Patch
+import importlib
+
+from clustering import subcluster
+importlib.reload(subcluster)
+from clustering.subcluster import ClusteringResult, ClusteringResultManager
+
+annotation_json_path = Path(
+    "/registered_report/cluster_annotations.json"
+)
+output_root = Path("/registered_report/output")
+input_dir   = Path("/registered_report/input/h5ad")
+output_root.mkdir(parents=True, exist_ok=True)
+
+# Slide order (conditions -> slide IDs)
+custom_order = [
+    "BIDMC_13","BIDMC_21","BIDMC_5","BIDMC_15","BIDMC_23","BIDMC_17",
+    "BIDMC_24","BIDMC_8","BIDMC_7","BIDMC_9","BIDMC_22","BIDMC_16",
+    "BIDMC_14","BIDMC_19","BIDMC_1","BIDMC_2","BIDMC_6","BIDMC_20",
+    "BIDMC_3","BIDMC_18","BIDMC_4","BIDMC_12","BIDMC_11","BIDMC_10"
+]
+slide_to_condition = {f"slide_{int(b.split('_')[1]):02d}": b for b in custom_order}
+condition_to_slide = {v: k for k, v in slide_to_condition.items()}
+
+POS_COLOR = "#FF8C00"  # orange
+NEG_COLOR = "#D9D9D9"  # light gray
+
+# Target checks (original + cross-specificity)
+# (title, target cell type label, candidate marker names, palette key)
+ORIGINAL_PAIRS = [
+    ("CD20 in B cells",                 "B cells",                 ["CD20"],                "B cells"),
+    ("PAX5 in B cells",                 "B cells",                 ["PAX5","Pax5"],         "B cells"),
+    ("CD3 in T cells",                  "T cells",                 ["CD3"],                 "T cells"),
+    ("CD8 in CD8+ T cells",             "CD8+ T cells",            ["CD8"],                 "CD8+ T cells"),
+    ("CD15 in neutrophils",             "Neutrophils and Unknown", ["CD15"],                "Neutrophils and Unknown"),
+]
+CROSS_SPEC_PAIRS = [
+    ("CD20 in T cells",                 "T cells",                 ["CD20"],                "T cells"),
+    ("CD3 in B cells",                  "B cells",                 ["CD3"],                 "B cells"),
+    ("PAX5 in T cells",                 "T cells",                 ["PAX5","Pax5"],         "T cells"),
+    ("CD8 in B cells",                  "B cells",                 ["CD8"],                 "B cells"),
+    ("FoxP3 in Neutrophils",            "Neutrophils and Unknown", ["FOXP3","FoxP3"],       "Neutrophils and Unknown"),
+    ("CD15 in CD8+ T cells",            "CD8+ T cells",            ["CD15"],                "CD8+ T cells"),
+]
+PAIRS = ORIGINAL_PAIRS + CROSS_SPEC_PAIRS  # full ordered list
+
+# ---- T-family handling ----
+INCLUDE_TREGS_IN_T_FAMILY = True
+T_CELL_FAMILY = (
+    "T cells", "CD8+ T cells", "CD8- T cells"
+) + (("Tregs",) if INCLUDE_TREGS_IN_T_FAMILY else ())
+
+def members_for(target_ct: str) -> tuple[str, ...]:
+    """Return the set of annotation labels that count as 'in-class' for a target."""
+    if target_ct == "T cells":
+        return T_CELL_FAMILY
+    return (target_ct,)
+
+def _find_var(adata: ad.AnnData, candidates) -> str | None:
+    """Return the first adata.var that matches any candidate (case-insensitive)."""
+    lower_map = {v.lower(): v for v in adata.var_names}
+    for c in candidates:
+        if c.lower() in lower_map:
+            return lower_map[c.lower()]
+    return None
+
+
+def _dense1(col) -> np.ndarray:
+    """Return dense 1D np.array from AnnData column (handles sparse)."""
+    if hasattr(col, "A1"):  # scipy sparse
+        return col.A1
+    return np.asarray(col).reshape(-1)
+
+with open(annotation_json_path) as f:
+    annotations_all = json.load(f)
+
+# normalize annotation strings, drop "Artifacts"
+for slide, cluster_dict in annotations_all.items():
+    for k, v in list(cluster_dict.items()):
+        if v == "Artifacts":
+            cluster_dict[k] = ""
+        elif isinstance(v, str):
+            cluster_dict[k] = v.strip()
+
+#per-slide % change vs cohort baseline (in-class mean vs cohort in-class mean)
+in_means = {}  # {(slide_key, pair_title): mean_in}
+baseline_acc = {title: {"sum": 0.0, "n": 0} for (title, *_r) in PAIRS}
+
+for slide_key in annotations_all.keys():
+    h5ad_path  = input_dir / f"{slide_key}_adata.h5ad"
+    out_dir    = output_root / f"{slide_key}_adata_k=200"
+    geojson_dir = out_dir / "geojson"
+
+    if not h5ad_path.exists() or not geojson_dir.is_dir():
+        continue
+    cdirs = [d for d in geojson_dir.iterdir() if d.is_dir()]
+    if not cdirs:
+        continue
+    clustering_id = max(cdirs, key=lambda d: d.stat().st_mtime).name
+
+    # load data + annotations aligned to obs
+    _ = ClusteringResult.pop(clustering_id=clustering_id, output_dir=out_dir)
+    adata = ad.read_h5ad(h5ad_path)
+    manager = ClusteringResultManager(output_dir=out_dir, unit_ids=adata.obs.index)
+    ann = manager.summary_df["annotation"].reindex(adata.obs.index).fillna("")
+
+    for (title, target_ct, marker_names, _color_key) in PAIRS:
+        var = _find_var(adata, marker_names)
+        if var is None:
+            in_means[(slide_key, title)] = np.nan
+            continue
+
+        x = _dense1(adata[:, var].X)
+        in_labels = members_for(target_ct)
+        mask_in = np.isin(ann.values, in_labels)  # per-cell-type selection only
+
+        if mask_in.sum() == 0:
+            in_means[(slide_key, title)] = np.nan
+            continue
+
+        xin = x[mask_in]
+        mean_in = float(np.mean(xin))
+        n_in    = int(mask_in.sum())
+
+        in_means[(slide_key, title)] = mean_in
+        baseline_acc[title]["sum"] += float(np.sum(xin))
+        baseline_acc[title]["n"]   += n_in
+
+# Cohort baselines (cell-count weighted)
+baseline = {title: (acc["sum"]/acc["n"] if acc["n"] > 0 else np.nan)
+            for title, acc in baseline_acc.items()}
+
+# Pass 2: % change vs cohort baseline
+records = []
+for (slide_key, title), mean_in in in_means.items():
+    b = baseline[title]
+    if np.isnan(mean_in) or np.isnan(b) or b == 0:
+        val = np.nan
+    else:
+        val = (mean_in - b) / b * 100.0
+    records.append({"slide": slide_key, "pair": title, "value": val})
+
+df1 = pd.DataFrame.from_records(records)
+wide1 = df1.pivot_table(index="slide", columns="pair", values="value", aggfunc="mean")
+
+# Order slides
+ordered_slide_ids = [
+    condition_to_slide[c] for c in custom_order
+    if c in condition_to_slide and condition_to_slide[c] in wide1.index
+]
+wide1 = wide1.loc[ordered_slide_ids]
+
+nrow = 2
+ncol = max(len(ORIGINAL_PAIRS), len(CROSS_SPEC_PAIRS))
+fig, axes = plt.subplots(nrow, ncol, figsize=(4.2*ncol, 6.2*nrow), sharey=True)
+
+# Ensure axes is 2D array
+if nrow == 1:
+    axes = np.array([axes])
+elif ncol == 1:
+    axes = axes.reshape(nrow, 1)
+
+
+def _plot_col(ax, title):
+    if title not in wide1.columns:
+        ax.set_visible(False)
+        return
+    vals = wide1[title]
+    colors = [POS_COLOR if (isinstance(v, (int, float)) and v >= 0) else NEG_COLOR for v in vals.values]
+    ax.bar(range(len(vals)), vals.values, color=colors, edgecolor="black", linewidth=0.5)
+    ax.set_title(f"{title}\nvs cohort baseline", fontsize=10)
+    ax.set_xticks(range(len(vals)))
+    ax.set_xticklabels([slide_to_condition.get(s, s) for s in vals.index], rotation=90, fontsize=7)
+    ax.axhline(0, color="black", linewidth=0.8)
+
+# Row 1: originals
+for j, (title, *_rest) in enumerate(ORIGINAL_PAIRS):
+    ax = axes[0, j]
+    _plot_col(ax, title)
+
+# Row 2: cross-specificity
+for j, (title, *_rest) in enumerate(CROSS_SPEC_PAIRS):
+    ax = axes[1, j]
+    _plot_col(ax, title)
+
+# Hide any unused axes
+for r in range(nrow):
+    for c in range(ncol):
+        if r == 0 and c >= len(ORIGINAL_PAIRS):
+            axes[r, c].set_visible(False)
+        if r == 1 and c >= len(CROSS_SPEC_PAIRS):
+            axes[r, c].set_visible(False)
+
+# Y-label on first visible axis
+axes[0, 0].set_ylabel("Δ vs cohort mean (%)")
+
+# Legend
+handles = [Patch(facecolor=POS_COLOR, edgecolor="black", label="≥ baseline"),
+           Patch(facecolor=NEG_COLOR, edgecolor="black", label="< baseline")]
+axes[0, 0].legend(handles=handles, loc="upper left", frameon=False, fontsize=9)
+
+plt.tight_layout()
+plt.savefig(output_root / "marker_specificity_vs_cohort_baseline_per_slide.svg",
+            dpi=300, bbox_inches="tight")
+plt.savefig(output_root / "marker_specificity_vs_cohort_baseline_per_slide.png",
+            dpi=300, bbox_inches="tight")
+plt.close()
+
+print("Saved Plot 1 (no whitelist, 2-row layout):",
+      output_root / "marker_specificity_vs_cohort_baseline_per_slide.png")

--- a/manual_annotation/05_submit_enrichment.slurm
+++ b/manual_annotation/05_submit_enrichment.slurm
@@ -1,0 +1,15 @@
+#!/bin/bash
+#SBATCH --job-name=annotation
+#SBATCH --partition=batch_cpu
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=8G
+#SBATCH --output=output_%A_%a.log
+#SBATCH --error=error_%A_%a.log
+#SBATCH --time=03:00:00
+
+ml .testing  common-571
+ml Miniforge3/24.11.3-0
+conda activate clustering_3.11
+
+python ./05_enrichment_plots.py

--- a/manual_annotation/DOCUMENTATION.md
+++ b/manual_annotation/DOCUMENTATION.md
@@ -1,0 +1,132 @@
+# How to run:
+
+## 1️⃣ 01_clustering.py
+
+**Purpose:**  
+Performs unsupervised clustering (PhenoGraph, k=200) per slide, generating heatmaps and GeoJSON files.
+
+**Inputs:**  
+- `input/h5ad/slide_{XX}_adata.h5ad`  
+- `input/geojson/{slide_prefix}.geojson`  
+
+**Outputs:**  
+- `output/slide_{XX}_adata_k=200/`  
+  - `clustering_results/*.csv` — cluster membership per cell  
+  - `heatmap_{slide}_dual_raw.png` — raw marker heatmap  
+  - `heatmap_{slide}_dual_vmin_vmax.png` — z-score heatmap  
+  - `geojson/` — updated GeoJSONs with cluster assignments  
+
+**Run manually:**  
+```bash
+python 01_clustering.py <slide_number>
+```
+
+**Run on SLURM:**  
+```bash
+sbatch 01_submit_clustering.slurm
+```
+
+---
+
+## 2️⃣ 02_annotation.py
+
+**Purpose:**  
+Loads `cluster_annotations.json` and applies cell type labels to each cluster.
+
+**Inputs:**  
+- `cluster_annotations.json`  
+- Clustering results from Step 1 (`clustering_results/`)  
+- `input/h5ad/*.h5ad`  
+
+**Outputs:**  
+- Annotated clustering heatmaps:  
+  - `heatmap_*_full_annotations.png/svg`  
+  - `heatmap_*_combined_annotations.png/svg`  
+- Updated clustering objects with annotations  
+
+**Run manually:**  
+```bash
+python 02_annotation.py
+```
+
+**Run on SLURM:**  
+```bash
+sbatch 02_submit_annotation.slurm
+```
+
+---
+
+## 3️⃣ 03_phenotype_map.py
+
+**Purpose:**  
+Renders per-FOV phenotype maps using segmentation masks and annotations.
+
+**Inputs:**  
+- `output/slide_{XX}_adata_k=200/clustering_results/*.csv`  
+- `MESMER_overlay/*.tiff` and `MESMER_mask/*.tiff`  
+
+**Outputs:**  
+- `output/slide_{XX}_adata_k=200/*.png, *.svg` — per-FOV colored phenotype maps  
+  (each cell colored by its annotation)
+
+**Run manually:**  
+```bash
+python 03_phenotype_map.py --slide 7
+```
+
+**Run on SLURM:**  
+```bash
+sbatch 03_submit_phenotype_map.slurm
+```
+
+---
+
+## 4️⃣ 04_stacked_bar_plots.py
+
+**Purpose:**  
+Generates stacked bar charts showing the fractional composition of annotations per slide.
+
+**Inputs:**  
+- `cluster_annotations.json`  
+- `input/h5ad/*.h5ad`  
+- Annotated clustering results from Step 2  
+
+**Outputs:**  
+- `annotation_mixed_vs_single_vs_unknown.svg`  
+  - Stacked bar plot with annotation fractions across slides  
+  - Categories: cell type, Mixed, Unknown  
+
+**Run manually:**  
+```bash
+python 04_stacked_bar_plots.py
+```
+
+**Run on SLURM:**  
+```bash
+sbatch 04_submit_stacked_bar_plot.slurm
+```
+
+---
+
+## 5️⃣ 05_enrichment_plots.py
+
+**Purpose:**  
+Computes cell-type enrichment and produces comparative plots across conditions.
+
+**Inputs:**  
+- Annotated clustering results (`output/*/`)  
+- Cell counts per annotation  
+
+**Outputs:**  
+- Enrichment heatmaps (`*.png`, `*.svg`)  
+- CSV tables with enrichment values per condition  
+
+**Run manually:**  
+```bash
+python 05_enrichment_plots.py
+```
+
+**Run on SLURM:**  
+```bash
+sbatch 05_submit_enrichment.slurm
+```


### PR DESCRIPTION
- Converted analysis notebooks into standalone Python scripts (01_clustering.py, 02_annotation.py, 03_phenotype_map.py)
- Added batch execution support (SLURM arrays/CLI) to automatically process all 24 slides.

+figure generation across steps (clustering heatmaps, phenotype maps, stacked bars, enrichment).

Added DOCUMENTATION.md