### PR TITLE
Use smoother sequential colormap for CV heatmap

### DIFF
--- a/helper.R
+++ b/helper.R
@@ -746,12 +746,15 @@ plot_heatmaps <- function(df_trans, out_folder, excluded_values, remove_values, 
   # 4. Heatmap of raw CV values (without Z-score transformation)
   cv_min <- min(cv_long$CV, na.rm = TRUE)
   cv_max <- max(cv_long$CV, na.rm = TRUE)
+  cv_p95 <- quantile(cv_long$CV, 0.95, na.rm = TRUE)
   cv_heatmap <- ggplot(cv_long, aes(x = Staining_condition, y = Marker, fill = CV)) +
     geom_tile(color = "black", lwd = 0.4) +
     geom_text(aes(label = sprintf("%.2f", CV)), size = 2.5) +
     scale_fill_gradientn(
-      colors = c("white", "#FBEDF6", "#F5D0E6", "#EAB2D5", "#D378B4", "#C11C84"),
-      values = c(0, 0.4, 0.6, 0.75, 0.85, 1),
+      colors = c("white", "#FFF5F0", "#FEE0D2", "#FCBBA1",
+                 "#FC9272", "#FB6A4A", "#DE2D26", "#A50F15"),
+      limits = c(0, cv_p95),
+      oob = scales::squish,
       na.value = "grey60"
     ) +
     theme_minimal() +


### PR DESCRIPTION
## Summary

Addresses the reviewer comment that the colormaps (Fig. 2B / Fig. S6) have **abrupt transitions near the center value, compressing differences at the extremes**.

Replaces the pink/magenta gradient on the raw CV heatmap (`plot_heatmaps` in `helper.R`) with a sequential **Reds** palette, and clips the scale at the **95th percentile** (`limits = c(0, cv_p95)` + `oob = scales::squish`) so quantitative differences read more evenly across conditions.

## Change

```r
cv_p95 <- quantile(cv_long$CV, 0.95, na.rm = TRUE)
...
scale_fill_gradientn(
  colors = c("white", "#FFF5F0", "#FEE0D2", "#FCBBA1",
             "#FC9272", "#FB6A4A", "#DE2D26", "#A50F15"),
  limits = c(0, cv_p95),
  oob = scales::squish,
  na.value = "grey60"
)
```

Single-file change to `helper.R` (+5/-2). Independent of the manual_annotation PRs (#3/#4).