### PR TITLE
Ignore agent/tooling state and Python egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ data_cellXpress/**
 *.tar
 *.tar.gz
 *.tgz
+
+# Agent / tooling state (machine-local, not part of the project)
+.omc/
+.claude/
+
+# Python packaging artifacts
+*.egg-info/


### PR DESCRIPTION
## Summary

Adds `.gitignore` rules so machine-local tooling state stops showing up as untracked in `git status`:

- `.omc/` and `.claude/` — agent/tooling state (oh-my-claudecode / Claude Code), not part of the project
- `*.egg-info/` — Python packaging artifact (e.g. `benchmarking_tissue_preparation.egg-info/`)

## Notes

- Verified no already-tracked file matches the new rules (`git ls-files | git check-ignore --stdin` is clean).
- Left untouched (intentionally not ignored): `AGENTS.md`, `rebuttal/`, and the in-progress reviewer R scripts — those are content decisions, not tooling noise.