### PR TITLE
feat: factorial CV reanalysis (Fig 3) — model + figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ _Mesmer and CellXpress are independent segmentation platforms—choose based on 
 | CellXpress segmentation analysis | `workflows/cellxpress_dataslide.R`| [data_cellXpress/README.md](data_cellXpress/README.md) ([CellXpress2 download](https://cellxpress.org/download)) |
 | Signal intensity ratio analysis  | `workflows/mesmer_signalnoise.R`  | [data_mesmer/README.md](data_mesmer/README.md)             |
 | CellXpress SNR analysis          | `workflows/cellxpress_snr.R`      | [data_cellXpress/README.md](data_cellXpress/README.md)     |
+| Factorial CV reanalysis          | `workflows/factorial_cv_model.R` → `workflows/factorial_cv_figures.R` | per-site factor effects on CV (η², adjusted mean CV, ranking table) |
 | Manual cell type annotation      | `manual_annotation/`              | [manual_annotation/README.md](manual_annotation/README.md) |
 | Balagan spatial heterogeneity    | `balagan_analysis/`               | [balagan_analysis/README.md](balagan_analysis/README.md)   |
 
@@ -87,6 +88,9 @@ flowchart TD
         H --> J
         I --> J
         M --> J
+        J --> N["workflows/factorial_cv_model.R"]
+        N --> O["workflows/factorial_cv_figures.R"]
+        O --> P[("Factor effects: η², adjusted mean CV, ranking table")]
     end
 
     subgraph stage2b["Stage 2: Python Annotation"]
@@ -109,6 +113,8 @@ pip install deepcell  # For Mesmer segmentation
 # R packages
 Rscript -e 'install.packages(c("dplyr", "tidyverse", "matrixStats", "ggcorrplot", "ggpubr", "tidyr", "rstatix", "readr", "svglite", "cowplot", "devtools", "qs"))'
 Rscript -e 'devtools::install_github("immunogenomics/presto")'
+# Additional packages for the factorial CV reanalysis (workflows/factorial_cv_*.R)
+Rscript -e 'install.packages(c("car", "effectsize", "emmeans", "patchwork", "ggtext", "funkyheatmap", "ragg"))'
 ```
 
 Then follow the [Workflow Documentation](#workflow-documentation) for your analysis of interest.
@@ -128,7 +134,9 @@ Then follow the [Workflow Documentation](#workflow-documentation) for your analy
 │   ├── mesmer_dataslide.R          # Main Mesmer workflow
 │   ├── mesmer_signalnoise.R        # Signal intensity ratio analysis
 │   ├── cellxpress_dataslide.R      # Main CellXpress workflow
-│   └── cellxpress_snr.R            # CellXpress SNR analysis
+│   ├── cellxpress_snr.R            # CellXpress SNR analysis
+│   ├── factorial_cv_model.R        # Factorial models of CV → effect size + adjusted mean CV tables
+│   └── factorial_cv_figures.R      # Panel C (adjusted mean CV), Panel D (η² bubble), ranking table
 ├── scripts/                        # One-off utilities
 ├── R/
 │   └── helper.R                    # Shared R functions

--- a/workflows/factorial_cv_figures.R
+++ b/workflows/factorial_cv_figures.R
@@ -1,0 +1,290 @@
+#!/usr/bin/env Rscript
+# =============================================================================
+# Factorial CV reanalysis - Stage 2: figures
+#
+# Reads the tidy tables from Stage 1 (results/factorial_cv/*.csv) and renders the
+# three promoted Figure-3 deliverables, one per site where applicable:
+#   - adjusted_mean_cv_{site}   Panel C: EMM dot + 95% CI per factor level
+#                               (left factor strips, alternating bands,
+#                                grand-mean dashed line, best level haloed)
+#   - effect_size_bubble        Panel D: cross-site partial-eta^2 bubble matrix
+#   - ranking_table_{site}      funkyheatmap "Conditions Ranked Top->Bottom" table
+#
+# Consolidated R-only port of A_importance_matrix.R, the build_emm panel of
+# R3_stats_v3_funky_consistent.R, and R3_concept1_funky.R.
+#
+# Run from the repo root (after factorial_cv_model.R):
+#   Rscript workflows/factorial_cv_figures.R
+# =============================================================================
+
+suppressPackageStartupMessages({
+  library(readr); library(dplyr); library(tidyr); library(stringr)
+  library(forcats); library(ggplot2); library(ggtext); library(scales)
+  library(svglite); library(cowplot); library(tibble); library(funkyheatmap)
+})
+
+io_dir <- "results/factorial_cv"
+stopifnot(dir.exists(io_dir))
+
+effect <- read_csv(file.path(io_dir, "effect_size.csv"), show_col_types = FALSE)
+emm    <- read_csv(file.path(io_dir, "adjusted_mean_cv.csv"), show_col_types = FALSE)
+master <- read_csv(file.path(io_dir, "ranking_master_table.csv"), show_col_types = FALSE)
+
+SITE_COL   <- c(BIDMC = "#B52427", Stanford = "#FFC130", Roche = "#1E94CF")
+SITE_TITLE <- c(BIDMC = "BIDMC-Harvard", Stanford = "Stanford", Roche = "Roche")
+sites      <- c("BIDMC", "Stanford", "Roche")
+
+save_fig <- function(plot, stem, w, h) {
+  ggsave(paste0(stem, ".svg"), plot, width = w, height = h,
+         device = svglite::svglite, fix_text_size = FALSE)
+  ggsave(paste0(stem, ".pdf"), plot, width = w, height = h, device = grDevices::cairo_pdf)
+  ggsave(paste0(stem, ".png"), plot, width = w, height = h, dpi = 600, bg = "white")
+}
+
+# =============================================================================
+# PANEL C - Adjusted mean CV (EMM dot + 95% CI) per factor, per site
+# Factor rows: HIER duration / Ab staining / HIER buffer; best level haloed;
+# grand-mean dashed reference; alternating grey factor bands; left strip labels.
+# =============================================================================
+FACTOR_LABEL <- c("HIER duration" = "HIER duration",
+                  "Staining" = "Ab staining", "Buffer" = "HIER buffer")
+FACTOR_ORDER <- c("HIER duration", "Ab staining", "HIER buffer")  # top -> bottom
+
+build_panel_c <- function(site) {
+  col <- SITE_COL[[site]]
+  d <- emm %>%
+    filter(site == !!site) %>%
+    mutate(factor = dplyr::recode(factor, !!!FACTOR_LABEL),
+           factor = factor(factor, levels = intersect(FACTOR_ORDER, unique(factor))),
+           level = str_replace(level, "overnight", "O/N"))  # match figure abbreviation
+
+  # within each factor: lowest CV (best) at the TOP -> y levels = descending CV
+  d <- d %>%
+    group_by(factor) %>%
+    mutate(is_best = adjusted_cv == min(adjusted_cv)) %>%
+    ungroup() %>%
+    arrange(factor, desc(adjusted_cv)) %>%
+    mutate(level = fct_inorder(level))
+
+  grand <- mean(d$adjusted_cv)
+
+  # alternating background bands (1st & 3rd factor grey, 2nd white)
+  bands <- tibble(factor = levels(d$factor)) %>%
+    mutate(factor = factor(factor, levels = levels(d$factor)),
+           fill = ifelse(seq_len(n()) %% 2 == 1, "#F2F2F2", "#FFFFFF"))
+
+  ggplot(d, aes(x = adjusted_cv, y = level)) +
+    geom_rect(data = bands, inherit.aes = FALSE,
+              aes(fill = fill), xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf) +
+    scale_fill_identity() +
+    geom_vline(xintercept = grand, linetype = "dashed",
+               colour = "#7A7A7A", linewidth = 0.35) +
+    geom_linerange(aes(xmin = lower_cl, xmax = upper_cl),
+                   colour = col, linewidth = 0.7) +
+    # best level: open halo ring behind the dot
+    geom_point(data = dplyr::filter(d, is_best),
+               shape = 21, size = 4.4, fill = NA, colour = col, stroke = 0.9) +
+    geom_point(size = 2.4, shape = 21, fill = col, colour = "white", stroke = 0.4) +
+    facet_grid(factor ~ ., scales = "free_y", space = "free_y", switch = "y") +
+    scale_x_continuous(labels = label_number(accuracy = 0.01)) +
+    labs(title = paste0("Adjusted Mean CV for Each Factor at ", SITE_TITLE[[site]]),
+         x = "Adjusted mean CV (lower = better)", y = NULL) +
+    theme_classic(base_size = 11) +
+    theme(
+      strip.placement  = "outside",
+      strip.background  = element_blank(),
+      strip.text.y.left = element_text(angle = 90, face = "bold", size = 10),
+      panel.spacing.y   = unit(2, "pt"),
+      axis.line.y       = element_blank(),
+      axis.ticks.y      = element_blank(),
+      plot.title        = element_text(face = "bold", size = 12, hjust = 0.5),
+      plot.title.position = "plot"
+    )
+}
+
+for (s in sites) {
+  message("Panel C: ", s)
+  p <- build_panel_c(s)
+  n <- nrow(filter(emm, site == s))
+  save_fig(p, file.path(io_dir, paste0("adjusted_mean_cv_", s)),
+           w = 6.0, h = 1.2 + 0.42 * n)
+}
+
+# =============================================================================
+# PANEL D - "Which prep knob matters" importance matrix (port of A_importance_matrix.R)
+# rows = HIER buffer / Ab staining / HIER duration; cols = 3 sites;
+# dot AREA = partial eta^2, colored by site; absent cells render "n/a".
+# =============================================================================
+build_panel_d <- function() {
+  factor_levels <- c("Buffer", "Staining", "HIER duration")
+  factor_labs   <- c(Buffer = "HIER buffer", Staining = "Ab staining",
+                     `HIER duration` = "HIER duration")
+  site_labs <- c(
+    BIDMC = "BIDMC<br><span style='font-size:6.5pt;color:#666666'>(Harvard)</span>",
+    Stanford = "Stanford", Roche = "Roche")
+
+  eff <- effect %>%
+    mutate(factor = ifelse(factor == "Staining protocol", "Staining", factor)) %>%
+    filter(factor %in% factor_levels, site %in% sites)
+
+  grid <- expand.grid(factor = factor_levels, site = sites, stringsAsFactors = FALSE)
+  dat <- grid %>%
+    left_join(eff %>% select(site, factor, eta2_partial), by = c("factor", "site")) %>%
+    mutate(site = factor(site, levels = sites),
+           factor = factor(factor, levels = rev(factor_levels)),
+           present = !is.na(eta2_partial))
+  present_dat <- dat %>% filter(present)
+  absent_dat  <- dat %>% filter(!present)
+
+  max_eta <- max(present_dat$eta2_partial)
+  size_breaks <- c(0.02, 0.05, 0.10, 0.14); size_breaks <- size_breaks[size_breaks <= max_eta * 1.05]
+  present_dat <- present_dat %>%
+    mutate(lab_size = scales::rescale(sqrt(eta2_partial), to = c(2.1, 3.0),
+                                      from = c(0, sqrt(max_eta))))
+
+  th <- theme_minimal(base_size = 8, base_family = "sans") +
+    theme(
+      panel.grid = element_blank(), axis.title = element_blank(),
+      axis.text.x = element_markdown(size = 9, face = "bold", margin = margin(b = 2)),
+      axis.text.y = element_text(size = 9, face = "bold", hjust = 1),
+      axis.text.x.top = element_markdown(size = 9, face = "bold"),
+      plot.title = element_text(size = 11, face = "bold", hjust = 0, margin = margin(b = 2)),
+      plot.subtitle = element_markdown(size = 8, colour = "#444444", hjust = 0,
+                                       margin = margin(b = 10), lineheight = 1.25),
+      plot.caption = element_textbox_simple(size = 6.5, colour = "#666666", hjust = 0,
+                                            halign = 0, margin = margin(t = 12), lineheight = 1.35),
+      legend.position = "bottom", legend.box = "horizontal",
+      legend.title = element_text(size = 7.5), legend.text = element_text(size = 7),
+      legend.margin = margin(2, 6, 2, 6), plot.margin = margin(14, 18, 10, 14))
+
+  ggplot() +
+    geom_tile(data = dat, aes(x = site, y = factor), fill = NA, colour = "grey92",
+              linewidth = 0.3, width = 0.96, height = 0.96) +
+    geom_text(data = absent_dat, aes(x = site, y = factor), label = "n/a",
+              colour = "grey75", size = 2.7, fontface = "italic") +
+    geom_point(data = present_dat, aes(x = site, y = factor, size = eta2_partial, fill = site),
+               shape = 21, colour = "white", stroke = 0.6, alpha = 0.95) +
+    geom_text(data = present_dat, aes(x = site, y = factor, label = sprintf("%.3f", eta2_partial)),
+              size = present_dat$lab_size, vjust = 0.5, fontface = "bold",
+              colour = ifelse(present_dat$site == "Stanford", "#5a4500", "white")) +
+    scale_x_discrete(position = "top", labels = site_labs, expand = expansion(add = 0.55)) +
+    scale_y_discrete(labels = factor_labs, expand = expansion(add = 0.55)) +
+    scale_fill_manual(values = SITE_COL, guide = "none") +
+    scale_size_area(name = expression(paste("Partial ", eta^2, " (effect size)")),
+                    max_size = 23, breaks = size_breaks, labels = sprintf("%.2f", size_breaks),
+                    limits = c(0, max_eta),
+                    guide = guide_legend(override.aes = list(fill = "grey55", colour = "white",
+                                                             stroke = 0.5),
+                                         title.position = "top", nrow = 1, order = 1,
+                                         label.position = "bottom")) +
+    labs(
+      title = "Which prep knob matters, and where?",
+      subtitle = paste0("Dot <b>area</b> = partial &eta;<sup>2</sup> (share of CV variance ",
+                        "explained by each factor), colored by site.<br>",
+                        "<span style='color:#B52427'>&#9679; BIDMC</span> &nbsp; ",
+                        "<span style='color:#FFC130'>&#9679; Stanford</span> &nbsp; ",
+                        "<span style='color:#1E94CF'>&#9679; Roche</span>"),
+      caption = paste0("Buffer drives BIDMC &amp; Roche; staining dominates Stanford; HIER ",
+                       "duration is minor except at Roche. Blank cells (<i>n/a</i>) = factor ",
+                       "not tested at that site.<br>Partial &eta;<sup>2</sup> from per-site ",
+                       "factorial models of coefficient of variation (CV).")) +
+    th + coord_cartesian(clip = "off")
+}
+
+message("Panel D: importance matrix")
+save_fig(build_panel_d(), file.path(io_dir, "effect_size_bubble"), w = 6.7, h = 5.5)
+
+# =============================================================================
+# FUNKY RANKING TABLE  (port of R3_concept1_funky.R)
+# =============================================================================
+SITE_TBL_TITLE <- c(
+  BIDMC    = "Conditions Ranked from Top to Bottom for BIDMC-Harvard/Akoya PhenoCycler-Fusion",
+  Stanford = "Conditions Ranked from Top to Bottom for Stanford/RareCyte Orion",
+  Roche    = "Conditions Ranked from Top to Bottom for Roche/Akoya PhenoCycler-Fusion")
+
+W_RANK <- 1.4; W_DURATION <- 3.2; W_STAINING <- 4.0; W_BAR <- 4.0; W_LABEL <- 1.4
+POS_ARGS <- position_arguments(expand_xmax = 4, col_annot_offset = 4.2)
+
+build_funky <- function(site) {
+  is_bidmc <- site == "BIDMC"
+  d <- master %>% filter(site == !!site) %>% arrange(rank)
+  bmax <- max(d$avg_score_exact)
+  d <- d %>% mutate(
+    tie = ifelse(is.na(tie), "", tie),
+    performance = avg_score_exact / bmax,
+    avg_label = paste0("  ", avg_score),
+    rank_lab = paste0(rank, tie),
+    example_val = dplyr::case_when(rank == 1 ~ 1L, rank == 2 ~ 2L, rank == 3 ~ 3L,
+                                   rank == max(rank) ~ 4L, TRUE ~ NA_integer_))
+  buf_w <- max(nchar(d$hier_buffer)) * 0.34 + 0.6
+
+  data <- d %>% transmute(id = rank_lab, hier_duration, hier_buffer, ab_staining,
+                          performance, avg_label)
+
+  column_info <- tribble(
+    ~id,            ~name,           ~geom, ~group,      ~palette, ~width,     ~hjust,
+    "id",           "Rank",          "text","condition", NA,       W_RANK,     0,
+    "hier_duration","HIER duration", "text","condition", NA,       W_DURATION, 0,
+    "hier_buffer",  "HIER buffer",   "text","condition", NA,       buf_w,      0,
+    "ab_staining",  "Ab staining",   "text","condition", NA,       W_STAINING, 0,
+    "performance",  "Avg Score",     "bar", "score",     "perf",   W_BAR,      NA,
+    "avg_label",    "",              "text","score",     NA,       W_LABEL,    0)
+  column_info <- column_info %>% mutate(options = lapply(seq_len(n()), function(i) {
+    o <- list(width = width[i]); if (!is.na(hjust[i])) o$hjust <- hjust[i]; o
+  })) %>% select(id, name, geom, group, palette, options)
+
+  column_groups <- tribble(
+    ~group,      ~palette, ~level1,
+    "condition", "perf",   "Condition (HIER + antibody staining)",
+    "score",     "perf",   "Performance")
+  palettes <- list(perf = c("#DEEBF7", "#9ECAE1", "#4292C6", "#08519C"))
+
+  g <- funky_heatmap(data = data, column_info = column_info, column_groups = column_groups,
+                     palettes = palettes,
+                     legends = list(list(palette = "perf", enabled = FALSE)),
+                     position_args = POS_ARGS, add_abc = FALSE, scale_column = FALSE)
+  if (!is_bidmc) return(g)
+
+  # BIDMC: overlay the example-row color fills at the correct cells
+  vdata <- funkyheatmap:::verify_data(data)
+  vci   <- funkyheatmap:::verify_column_info(column_info, vdata)
+  vri   <- funkyheatmap:::verify_row_info(NULL, vdata)
+  vcg   <- funkyheatmap:::verify_column_groups(column_groups, vci)
+  vrg   <- funkyheatmap:::verify_row_groups(NULL, vri)
+  vpal  <- funkyheatmap:::verify_palettes(palettes, vci, data)
+  gp <- funkyheatmap:::calculate_geom_positions(vdata, vci, vri, vcg, vrg, vpal,
+                                                POS_ARGS, FALSE, FALSE)
+  row_pos <- gp$row_pos %>% mutate(rank = d$rank, example_val = d$example_val,
+                                   image_color = d$image_color)
+  col_pos <- gp$column_pos
+  zebra <- tryCatch(ggplot2::layer_data(g, 1L), error = function(e) NULL)
+  if (!is.null(zebra) && all(c("xmin", "xmax") %in% names(zebra))) {
+    data_xmin <- min(zebra$xmin, na.rm = TRUE); data_xmax <- max(zebra$xmax, na.rm = TRUE)
+  } else {
+    data_xmin <- min(col_pos$xmin); data_xmax <- max(col_pos$xmax)
+  }
+  ex_rows <- row_pos %>% filter(!is.na(example_val))
+  row_fill <- ex_rows %>% transmute(xmin = data_xmin, xmax = data_xmax,
+                                    ymin = ymin, ymax = ymax, fill = image_color)
+  row_fill_layer <- ggplot2::geom_rect(
+    data = row_fill, ggplot2::aes(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax),
+    fill = row_fill$fill, alpha = 1, inherit.aes = FALSE)
+  g$layers <- append(g$layers, list(row_fill_layer), after = 1L)
+  g
+}
+
+for (s in sites) {
+  message("Funky table: ", s)
+  g <- build_funky(s) + ggplot2::theme(plot.margin = ggplot2::margin(2, 16, 2, 16))
+  hm_h <- g$height; w <- g$width
+  title <- cowplot::ggdraw() +
+    cowplot::draw_label(SITE_TBL_TITLE[[s]], fontface = "bold", size = 9.5, x = 0.018, hjust = 0)
+  th <- 0.45; h <- hm_h + th
+  final <- cowplot::plot_grid(title, g, ncol = 1, rel_heights = c(th, hm_h))
+  stem <- file.path(io_dir, paste0("ranking_table_", s))
+  ggsave(paste0(stem, ".pdf"), final, width = w, height = h, device = grDevices::cairo_pdf)
+  ggsave(paste0(stem, ".svg"), final, width = w, height = h, device = svglite::svglite)
+  ggsave(paste0(stem, ".png"), final, width = w, height = h, dpi = 600, bg = "white")
+}
+
+message("DONE")

--- a/workflows/factorial_cv_model.R
+++ b/workflows/factorial_cv_model.R
@@ -1,0 +1,283 @@
+#!/usr/bin/env Rscript
+# =============================================================================
+# Factorial CV reanalysis - Stage 1: models + tidy tables
+#
+# Per-site factorial models of marker-level coefficient of variation (CV):
+#   BIDMC    : CV ~ buffer + hier_duration + staining + Marker   (24 conditions)
+#   Stanford : CV ~ hier_duration + staining + Marker            (12, Tris/EDTA only)
+#   Roche    : CV ~ buffer + hier_duration + Marker              (6,  25 C 1 h only)
+# Type II ANOVA -> partial eta-squared (effect size); emmeans -> adjusted mean CV.
+#
+# Consolidated R-only port of:
+#   rebuttal/scripts/R1_5_factorial_model_all_sites.R   (the statistical core)
+#   rebuttal/scripts/R3_build_viz_input.py              (pure relabel, no modeling)
+#   rebuttal/scripts/R3_fig3_master_table.py            (ranking + traffic-light colors)
+#
+# Run from the repo root:  Rscript workflows/factorial_cv_model.R
+# Inputs  (gitignored, produced by the main Mesmer workflow with *_all configs):
+#   results/out_{BIDMC,Stanford,Roche}_all/cv_values_long.csv
+#   results/out_{BIDMC,Stanford,Roche}_all/condition_summary.csv
+# Outputs -> results/factorial_cv/{effect_size,adjusted_mean_cv,ranking_master_table}.csv
+# =============================================================================
+
+suppressPackageStartupMessages({
+  library(readr)
+  library(dplyr)
+  library(tidyr)
+  library(car)          # Type II ANOVA
+  library(effectsize)   # partial eta-squared
+  library(emmeans)      # adjusted means (EMMs)
+})
+
+out_dir <- "results/factorial_cv"
+dir.create(out_dir, showWarnings = FALSE, recursive = TRUE)
+
+# ---- site metadata (platform labels printed in the figures) -----------------
+PLATFORM <- c(
+  BIDMC    = "Akoya PhenoCycler-Fusion",
+  Stanford = "RareCyte Orion",
+  Roche    = "Akoya PhenoCycler-Fusion"
+)
+
+# Staining display labels: EMM panel (R1_5) vs ranking table (R3_fig3_master).
+STAIN_EMM <- c("4C_ON" = "4 °C overnight", "25C_1h" = "25 °C 1 h",
+               "25C_ON" = "25 °C overnight", "37C_1h" = "37 °C 1 h")
+STAIN_TBL <- c("4C_ON" = "4 °C, O/N", "25C_1h" = "25 °C, 1 h",
+               "25C_ON" = "25 °C, O/N", "37C_1h" = "37 °C, 1 h")
+
+# Traffic-light example-row colors (rank 1/2/3, and last = worst).
+IMG_COLOR <- c("1" = "#8dc63f", "2" = "#eee827", "3" = "#f99d1c")
+IMG_LAST  <- "#f26858"
+
+require_input <- function(path) {
+  if (!file.exists(path)) {
+    stop("Missing required input: ", path,
+         "\n  Run the main Mesmer workflow for the corresponding *_all config first.",
+         call. = FALSE)
+  }
+  path
+}
+
+read_site_cv <- function(site) {
+  f <- require_input(file.path("results", paste0("out_", site, "_all"),
+                               "cv_values_long.csv"))
+  read_csv(f, show_col_types = FALSE) %>%
+    rename(condition_id = Staining_condition) %>%
+    filter(!Is_Excluded, !is.na(CV)) %>%
+    mutate(slide = as.integer(gsub(paste0(site, "_"), "", condition_id)))
+}
+
+# ---- per-site experimental-design lookups (encode the design; do not change) -
+# Model lookups use the full buffer names used for the statistics.
+bidmc_lookup <- data.frame(
+  slide = 1:24,
+  buffer = rep(c("Citraconic Anhydride", "Tris/EDTA"), each = 4, times = 3),
+  hier_duration = rep(c("10", "20", "40"), each = 8),
+  staining = rep(c("4C_ON", "25C_1h", "25C_ON", "37C_1h"), times = 6),
+  stringsAsFactors = FALSE
+)
+stanford_lookup <- data.frame(
+  slide = c(5:8, 13:16, 21:24),
+  hier_duration = rep(c("10", "20", "40"), each = 4),
+  staining = rep(c("4C_ON", "25C_1h", "25C_ON", "37C_1h"), times = 3),
+  stringsAsFactors = FALSE
+)
+roche_lookup <- data.frame(
+  slide = c(2, 6, 10, 14, 18, 22),
+  buffer = rep(c("Citrate-based pH6", "EDTA-based pH9"), times = 3),
+  hier_duration = rep(c("10", "20", "40"), each = 2),
+  stringsAsFactors = FALSE
+)
+
+# Table lookups use the figure's display abbreviations for buffer.
+tbl_lookup <- list(
+  BIDMC = data.frame(
+    slide = 1:24,
+    hier_buffer = rep(c("CA", "Tris/EDTA"), each = 4, times = 3),
+    hier_duration_min = rep(c("10", "20", "40"), each = 8),
+    stain_code = rep(c("4C_ON", "25C_1h", "25C_ON", "37C_1h"), times = 6),
+    stringsAsFactors = FALSE
+  ),
+  Stanford = data.frame(
+    slide = c(5:8, 13:16, 21:24),
+    hier_buffer = "Tris/EDTA",
+    hier_duration_min = rep(c("10", "20", "40"), each = 4),
+    stain_code = rep(c("4C_ON", "25C_1h", "25C_ON", "37C_1h"), times = 3),
+    stringsAsFactors = FALSE
+  ),
+  Roche = data.frame(
+    slide = c(2, 6, 10, 14, 18, 22),
+    hier_buffer = rep(c("Bond ER 1 (Citrate-based pH6)",
+                        "Bond ER 2 (EDTA-based pH9)"), times = 3),
+    hier_duration_min = rep(c("10", "20", "40"), each = 2),
+    stain_code = "25C_1h",
+    stringsAsFactors = FALSE
+  )
+)
+
+# ---- helpers to tidy model outputs ------------------------------------------
+tidy_eta <- function(anova_obj, recode_map) {
+  eta_squared(anova_obj, partial = TRUE) %>%
+    as.data.frame() %>%
+    filter(!grepl("Marker", Parameter)) %>%
+    mutate(factor = dplyr::recode(Parameter, !!!recode_map)) %>%
+    transmute(factor, eta2_partial = Eta2_partial,
+              ci_low = CI_low, ci_high = CI_high)
+}
+
+emm_factor <- function(model, spec, factor_label, level_fun) {
+  summary(emmeans(model, spec), infer = TRUE) %>%
+    as.data.frame() %>%
+    transmute(factor = factor_label,
+              level = level_fun(.),
+              adjusted_cv = emmean, lower_cl = lower.CL, upper_cl = upper.CL)
+}
+
+# =============================================================================
+# Fit the three site models
+# =============================================================================
+effect_frames <- list()
+emm_frames    <- list()
+
+## ---- BIDMC ------------------------------------------------------------------
+bidmc <- read_site_cv("BIDMC") %>%
+  left_join(bidmc_lookup, by = "slide") %>%
+  mutate(
+    buffer = factor(buffer),
+    hier_duration = factor(hier_duration, levels = c("10", "20", "40")),
+    staining = factor(staining, levels = c("4C_ON", "25C_1h", "25C_ON", "37C_1h")),
+    Marker = factor(Marker)
+  )
+contrasts(bidmc$buffer)        <- contr.sum(2)
+contrasts(bidmc$hier_duration) <- contr.sum(3)
+contrasts(bidmc$staining)      <- contr.sum(4)
+
+m_bidmc <- lm(CV ~ buffer + hier_duration + staining + Marker, data = bidmc)
+a_bidmc <- Anova(m_bidmc, type = "II")
+
+effect_frames$BIDMC <- tidy_eta(a_bidmc, c(
+  "buffer" = "Buffer", "hier_duration" = "HIER duration",
+  "staining" = "Staining protocol")) %>%
+  mutate(site = "BIDMC", platform = PLATFORM[["BIDMC"]], n_obs = nrow(bidmc))
+
+emm_frames$BIDMC <- bind_rows(
+  emm_factor(m_bidmc, ~ buffer, "Buffer", function(d) as.character(d$buffer)),
+  emm_factor(m_bidmc, ~ hier_duration, "HIER duration",
+             function(d) paste0(d$hier_duration, " min")),
+  emm_factor(m_bidmc, ~ staining, "Staining",
+             function(d) dplyr::recode(as.character(d$staining), !!!STAIN_EMM))
+) %>% mutate(site = "BIDMC", platform = PLATFORM[["BIDMC"]])
+
+## ---- Stanford ---------------------------------------------------------------
+stanford <- read_site_cv("Stanford") %>%
+  left_join(stanford_lookup, by = "slide") %>%
+  mutate(
+    hier_duration = factor(hier_duration, levels = c("10", "20", "40")),
+    staining = factor(staining, levels = c("4C_ON", "25C_1h", "25C_ON", "37C_1h")),
+    Marker = factor(Marker)
+  )
+contrasts(stanford$hier_duration) <- contr.sum(3)
+contrasts(stanford$staining)      <- contr.sum(4)
+
+m_stanford <- lm(CV ~ hier_duration + staining + Marker, data = stanford)
+a_stanford <- Anova(m_stanford, type = "II")
+
+effect_frames$Stanford <- tidy_eta(a_stanford, c(
+  "hier_duration" = "HIER duration", "staining" = "Staining protocol")) %>%
+  mutate(site = "Stanford", platform = PLATFORM[["Stanford"]], n_obs = nrow(stanford))
+
+emm_frames$Stanford <- bind_rows(
+  emm_factor(m_stanford, ~ hier_duration, "HIER duration",
+             function(d) paste0(d$hier_duration, " min")),
+  emm_factor(m_stanford, ~ staining, "Staining",
+             function(d) dplyr::recode(as.character(d$staining), !!!STAIN_EMM))
+) %>% mutate(site = "Stanford", platform = PLATFORM[["Stanford"]])
+
+## ---- Roche ------------------------------------------------------------------
+roche <- read_site_cv("Roche") %>%
+  left_join(roche_lookup, by = "slide") %>%
+  mutate(
+    buffer = factor(buffer),
+    hier_duration = factor(hier_duration, levels = c("10", "20", "40")),
+    Marker = factor(Marker)
+  )
+contrasts(roche$buffer)        <- contr.sum(2)
+contrasts(roche$hier_duration) <- contr.sum(3)
+
+m_roche <- lm(CV ~ buffer + hier_duration + Marker, data = roche)
+a_roche <- Anova(m_roche, type = "II")
+
+effect_frames$Roche <- tidy_eta(a_roche, c(
+  "buffer" = "Buffer", "hier_duration" = "HIER duration")) %>%
+  mutate(site = "Roche", platform = PLATFORM[["Roche"]], n_obs = nrow(roche))
+
+emm_frames$Roche <- bind_rows(
+  emm_factor(m_roche, ~ buffer, "Buffer", function(d) as.character(d$buffer)),
+  emm_factor(m_roche, ~ hier_duration, "HIER duration",
+             function(d) paste0(d$hier_duration, " min"))
+) %>% mutate(site = "Roche", platform = PLATFORM[["Roche"]])
+
+# =============================================================================
+# Write effect_size.csv + adjusted_mean_cv.csv  (folds R3_build_viz_input.py)
+# =============================================================================
+site_order <- c("BIDMC", "Stanford", "Roche")
+
+effect_size <- bind_rows(effect_frames[site_order]) %>%
+  select(site, platform, factor, eta2_partial, ci_low, ci_high, n_obs) %>%
+  arrange(match(site, site_order), desc(eta2_partial))
+write_csv(effect_size, file.path(out_dir, "effect_size.csv"))
+
+adjusted_mean_cv <- bind_rows(emm_frames[site_order]) %>%
+  select(site, platform, factor, level, adjusted_cv, lower_cl, upper_cl)
+write_csv(adjusted_mean_cv, file.path(out_dir, "adjusted_mean_cv.csv"))
+
+# =============================================================================
+# Write ranking_master_table.csv  (folds R3_fig3_master_table.py)
+# =============================================================================
+fmt_score <- function(v) ifelse(v >= 10, sprintf("%.1f", v), sprintf("%.2f", v))
+
+rank_one_site <- function(site) {
+  plat <- PLATFORM[[site]]
+  f <- require_input(file.path("results", paste0("out_", site, "_all"),
+                               "condition_summary.csv"))
+  cs <- read_csv(f, show_col_types = FALSE) %>%
+    mutate(slide = as.integer(gsub(paste0(site, "_"), "", Staining_condition))) %>%
+    inner_join(tbl_lookup[[site]], by = "slide") %>%
+    arrange(Average_Score) %>%                         # ascending: rank 1 = best
+    mutate(rank = row_number())
+
+  last <- max(cs$rank)
+  cs %>%
+    mutate(
+      tie = ifelse(duplicated(round(Average_Score, 2)) |
+                     duplicated(round(Average_Score, 2), fromLast = TRUE), "*", ""),
+      is_example = rank %in% c(1, 2, 3, last),
+      image_color = dplyr::case_when(
+        rank == last ~ IMG_LAST,
+        as.character(rank) %in% names(IMG_COLOR) ~ IMG_COLOR[as.character(rank)],
+        TRUE ~ ""
+      ),
+      ab_staining = dplyr::recode(stain_code, !!!STAIN_TBL),
+      hier_duration = paste0(hier_duration_min, " min"),
+      avg_score = fmt_score(Average_Score),
+      avg_score_exact = Average_Score,
+      site = .env$site, platform = plat
+    ) %>%
+    select(site, platform, rank, tie, hier_duration, hier_buffer, ab_staining,
+           avg_score, avg_score_exact, is_example, image_color)
+}
+
+ranking_master <- bind_rows(lapply(site_order, rank_one_site))
+write_csv(ranking_master, file.path(out_dir, "ranking_master_table.csv"))
+
+# =============================================================================
+# Report
+# =============================================================================
+cat("\nWrote to", out_dir, ":\n")
+for (f in c("effect_size.csv", "adjusted_mean_cv.csv", "ranking_master_table.csv")) {
+  cat(sprintf("  %-26s %d rows\n", f,
+              nrow(read_csv(file.path(out_dir, f), show_col_types = FALSE))))
+}
+cat("\n--- effect_size.csv (partial eta^2) ---\n")
+print(as.data.frame(effect_size), row.names = FALSE)
+cat("\nDone.\n")


### PR DESCRIPTION
## Summary
Promotes the **factorial statistical reanalysis of CV** (the Fig 3 revision) from the `rebuttal/` scratch dir into a tracked, reproducible **2-script R pipeline**. Main previously had *no* factorial statistics. Run from repo root.

## Deliverables (match the revised figure)
| | Output |
|---|---|
| **Panel C** Adjusted Mean CV per factor (BIDMC headline; Stanford/Roche too) | `results/factorial_cv/adjusted_mean_cv_{site}.{svg,pdf,png}` |
| **Panel D** Effect-size bubble matrix (partial η², 3 sites) | `results/factorial_cv/effect_size_bubble.{svg,pdf,png}` |
| **Ranking table** (funkyheatmap "Conditions Ranked Top→Bottom") | `results/factorial_cv/ranking_table_{site}.{svg,pdf,png}` |
| Tidy stats tables | `results/factorial_cv/{effect_size,adjusted_mean_cv,ranking_master_table}.csv` |

## Pipeline
- **`workflows/factorial_cv_model.R`** — per-site `lm(CV ~ factors + Marker)`, Type II ANOVA → partial η², `emmeans` → adjusted mean CV. Folds in the two former Python relabel steps (`R3_build_viz_input.py`, `R3_fig3_master_table.py`) → **no Python dependency**.
- **`workflows/factorial_cv_figures.R`** — renders Panels C/D + the funkyheatmap table from the Stage 1 CSVs.

## Faithfulness (consolidated R-only port — verified)
Regenerated values match the rebuttal's existing CSVs to **machine precision** (max |Δ| ~1e-16) and the submitted figure's anchors exactly:
- partial η² — BIDMC: buffer 0.074 / staining 0.062 / duration 0.020; Stanford: staining 0.138 / duration 0.018; Roche: buffer 0.056 / duration 0.044
- ranking table: rank order, avg scores, buffer labels, and traffic-light colors identical for all 3 sites

## Inputs / prerequisites
Reads `results/out_{BIDMC,Stanford,Roche}_all/{cv_values_long,condition_summary}.csv` — produced by the main Mesmer workflow with the `*_all` configs. The model script errors clearly if an input is missing.

## Notes
- Outputs land in gitignored `results/factorial_cv/` (regenerable, consistent with the rest of the repo).
- `rebuttal/` untouched (read-only source); root `factorial_linear_model.R` (a different older per-marker model) left as-is.
- README workflow table, mermaid, dependency list (`car`, `effectsize`, `emmeans`, `patchwork`, `ggtext`, `funkyheatmap`, `ragg`), and directory tree updated.

## Test plan
1. Run the main Mesmer workflow for `BIDMC_all`, `Stanford_all`, `Roche_all` (or use existing `results/`).
2. `Rscript workflows/factorial_cv_model.R` → 3 CSVs in `results/factorial_cv/`.
3. `Rscript workflows/factorial_cv_figures.R` → 14 figure files; visually compare Panels C/D + ranking table to the revised figure.