### PR TITLE
chore: exclude rebuttal materials from the public repo; fix Fig 3 bar palette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,9 +51,16 @@ data_cellXpress/**
 *.tar.gz
 *.tgz
 
+# Manuscript revision materials: unpublished text, figures and reviewer
+# correspondence. This repository is public and is the URL cited by the paper,
+# so none of it may be tracked here.
+rebuttal/
+
 # Agent / tooling state (machine-local, not part of the project)
 .omc/
 .claude/
+AGENTS.md
+REORG_PLAN.md
 
 # Python packaging artifacts
 *.egg-info/

--- a/workflows/factorial_cv_figures.R
+++ b/workflows/factorial_cv_figures.R
@@ -212,14 +212,20 @@ POS_ARGS <- position_arguments(expand_xmax = 4, col_annot_offset = 4.2)
 
 # Shared "Performance" gradient (matches the funkyheatmap bar fill) + a standalone
 # horizontal colorbar legend keyed to the ACTUAL Avg Score range for each site.
+# funkyheatmap maps a bar's numeric colour by *discrete* palette index
+# (round(value * (n-1)) + 1), so a 4-colour palette yields only ~3 visible shades.
+# Interpolating to a 100-step ramp makes the bars a smooth gradient that matches
+# the legend. The bars are coloured via a separate `perf_color` column rescaled to
+# the observed score range, so light->dark spans min->max exactly like the legend.
 PERF_COLORS <- c("#DEEBF7", "#9ECAE1", "#4292C6", "#08519C")
+PERF_RAMP   <- grDevices::colorRampPalette(PERF_COLORS)(100)
 
 make_perf_legend <- function(site) {
   rng <- range(master$avg_score_exact[master$site == site])
   p <- ggplot(tibble(v = rng), aes(x = v, y = 1, fill = v)) +
     geom_tile() +
     scale_fill_gradientn(
-      colours = PERF_COLORS, limits = rng,
+      colours = PERF_RAMP, limits = rng,
       breaks = rng, labels = sprintf("%.1f", rng),
       name = "Avg Score (lower = better)",
       guide = guide_colourbar(title.position = "top", title.hjust = 0, ticks = FALSE,
@@ -240,6 +246,9 @@ build_funky <- function(site) {
   d <- d %>% mutate(
     tie = ifelse(is.na(tie), "", tie),
     performance = avg_score_exact / bmax,
+    # bar fill spans the full observed score range (min -> lightest, max -> darkest),
+    # matching the colorbar legend; bar *length* stays = performance.
+    perf_color = scales::rescale(avg_score_exact, to = c(0, 1)),
     avg_label = paste0("  ", avg_score),
     rank_lab = paste0(rank, tie),
     example_val = dplyr::case_when(rank == 1 ~ 1L, rank == 2 ~ 2L, rank == 3 ~ 3L,
@@ -247,25 +256,25 @@ build_funky <- function(site) {
   buf_w <- max(nchar(d$hier_buffer)) * 0.34 + 0.6
 
   data <- d %>% transmute(id = rank_lab, hier_duration, hier_buffer, ab_staining,
-                          performance, avg_label)
+                          performance, perf_color, avg_label)
 
   column_info <- tribble(
-    ~id,            ~name,           ~geom, ~group,      ~palette, ~width,     ~hjust,
-    "id",           "Rank",          "text","condition", NA,       W_RANK,     0,
-    "hier_duration","HIER duration", "text","condition", NA,       W_DURATION, 0,
-    "hier_buffer",  "HIER buffer",   "text","condition", NA,       buf_w,      0,
-    "ab_staining",  "Ab staining",   "text","condition", NA,       W_STAINING, 0,
-    "performance",  "Avg Score",     "bar", "score",     "perf",   W_BAR,      NA,
-    "avg_label",    "",              "text","score",     NA,       W_LABEL,    0)
+    ~id,            ~name,           ~geom, ~group,      ~palette, ~id_color,    ~width,     ~hjust,
+    "id",           "Rank",          "text","condition", NA,       NA,           W_RANK,     0,
+    "hier_duration","HIER duration", "text","condition", NA,       NA,           W_DURATION, 0,
+    "hier_buffer",  "HIER buffer",   "text","condition", NA,       NA,           buf_w,      0,
+    "ab_staining",  "Ab staining",   "text","condition", NA,       NA,           W_STAINING, 0,
+    "performance",  "Avg Score",     "bar", "score",     "perf",   "perf_color", W_BAR,      NA,
+    "avg_label",    "",              "text","score",     NA,       NA,           W_LABEL,    0)
   column_info <- column_info %>% mutate(options = lapply(seq_len(n()), function(i) {
     o <- list(width = width[i]); if (!is.na(hjust[i])) o$hjust <- hjust[i]; o
-  })) %>% select(id, name, geom, group, palette, options)
+  })) %>% select(id, name, geom, group, palette, id_color, options)
 
   column_groups <- tribble(
     ~group,      ~palette, ~level1,
     "condition", "perf",   "Condition (HIER + antibody staining)",
     "score",     "perf",   "Performance")
-  palettes <- list(perf = PERF_COLORS)
+  palettes <- list(perf = PERF_RAMP)
 
   g <- funky_heatmap(data = data, column_info = column_info, column_groups = column_groups,
                      palettes = palettes,


### PR DESCRIPTION
Two independent changes, split into one commit each.

### 1. `chore(gitignore)`: keep manuscript revision material out of the public repo

This repository is public and is the URL cited by the paper. The local `rebuttal/`
directory (242 MB) holds the unpublished manuscript LaTeX source, figure artwork
(`.ai`), and reviewer correspondence (`.docx`). The existing `*.zip` rule caught the
archives but not those, so a `git add -A` would have published all of it. Verified
that nothing under `rebuttal/` has ever entered git history, so no history rewrite
is needed.

`AGENTS.md` and `REORG_PLAN.md` are machine-local tooling artefacts, now ignored
alongside `.claude/` and `.omc/`.

Also removes the untracked root `factorial_linear_model.R`. It is an earlier draft
superseded by `workflows/factorial_cv_model.R`, and not merely a duplicate: it fits a
different model (staining split into temperature and duration) and reports plain
eta-squared rather than the partial eta-squared the paper reports. Leaving it in a
public repo would present readers with two contradictory factorial models.

### 2. `fix(fig3)`: bar fill now matches the colorbar legend

`funkyheatmap` colours a bar by discrete palette index, so the 4-colour palette
rendered only about 3 visible shades and did not match the continuous legend beside
it. The palette is now interpolated to a 100-step ramp, and bars are coloured from a
separate `perf_color` column rescaled to the observed score range, so light-to-dark
spans min-to-max exactly as the legend claims. Bar *length* still encodes performance.

### Not included

The `06_correlation_analysis.R` MEAN to MEDIAN tau-rank fix (Supp Fig 12C) is held
back pending a decision on the manuscript side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)