### PR TITLE
fix(balagan): stop double-negating alpha; rank tau by median as the paper states

### DIFF
--- a/balagan_analysis/04_plot_rank_correlations.R
+++ b/balagan_analysis/04_plot_rank_correlations.R
@@ -51,10 +51,11 @@ cv_rank_data <- data.frame(
 # --- Process 2: Alpha Rank ---
 cat("Loading Stable Alpha data...\n")
 alpha_rank_data <- read_csv(alpha_data_file, show_col_types = FALSE) %>%
-  # Create the same "slideX" key for joining
-  mutate(Slide_Name = paste0("slide", gsub(".*slide(\\d+).*", "\\1", Slide)), median_alpha_slope=median_alpha_slope*-1) %>%
-  # Rank the slides based on their slope
-  # A lower (more negative) slope is ranked first (Rank 1)
+  # Create the same "slideX" key for joining.
+  # median_alpha_slope is already the positive heterogeneity exponent: script 01
+  # negates the raw log-log slope before taking the median. Do not negate again.
+  mutate(Slide_Name = paste0("slide", gsub(".*slide(\\d+).*", "\\1", Slide))) %>%
+  # Rank the slides by alpha (Rank 1 = least heterogeneous)
   mutate(alpha_slope_rank = rank(median_alpha_slope, ties.method = "min")) %>%
   select(Slide_Name, alpha_slope_rank, median_alpha_slope)
 

--- a/balagan_analysis/06_correlation_analysis.R
+++ b/balagan_analysis/06_correlation_analysis.R
@@ -60,11 +60,18 @@ cat("Loading core datasets...\n")
 alpha_slope_file <- file.path(consistency_dir, "AGGREGATE_stable_alpha_slopes.csv")
 stable_alpha_slopes <- read_csv(alpha_slope_file, show_col_types = FALSE) %>%
   mutate(Slide_Name = paste0("slide", gsub(".*slide(\\d+).*", "\\1", Slide))) %>%
-  mutate(Alpha = median_alpha_slope * -1) %>%  # Convert to positive exponent
+  # 01_check_consistency_and_calc_alpha.R already negates the raw log-log slope
+  # before taking the median, so this column is the positive heterogeneity
+  # exponent. Do not negate it again.
+  mutate(Alpha = median_alpha_slope) %>%
   select(Slide_Name, Alpha, sd_alpha_slope)
 
 # --- Balagan Metrics: Tau Ranks ---
-tau_rank_file <- file.path(tau_rank_dir, "TABLE_stable_MEAN_rank_stability.csv")
+# 05_calculate_tau_rank_stability.R writes both a MEAN- and a MEDIAN-based table.
+# The MEDIAN one is the published metric: tau is pooled across the 100 runs by
+# median before the slides are ranked at each FOV width (mean_rank then averages
+# those ranks over the 10 FOV widths, in both tables).
+tau_rank_file <- file.path(tau_rank_dir, "TABLE_stable_MEDIAN_rank_stability.csv")
 stable_tau_ranks <- read_csv(tau_rank_file, show_col_types = FALSE) %>%
   dplyr::rename(Average_Tau_Rank = mean_rank) %>%
   select(Slide_Name, Average_Tau_Rank, stability_sd, stability_iqr)


### PR DESCRIPTION
Two defects that stop the committed pipeline from reproducing the published correlations. Found while verifying the Supp Fig 12 statistics against the raw Balagan outputs.

### 1. Alpha was negated twice

`01_check_consistency_and_calc_alpha.R` negates the raw log-log slope **before** taking the median, so `AGGREGATE_stable_alpha_slopes.csv` already holds the positive heterogeneity exponent (verified: `slide1 = +1.0387`). Scripts `04` and `06` then negated it **again**.

Anyone cloning this repo and running `01 -> 06` end-to-end therefore got **negative alpha**, flipping the sign of every alpha correlation. Fig 4D would come out at **r = +0.44** instead of the published **-0.44**.

The published figures were produced before the negation was moved into `01`; the two downstream call sites were never updated. `06:341` is deliberately untouched, since it derives the slope from scratch and correctly negates once.

### 2. Tau rank used the mean, not the median

The Methods, the Results, and the Extended Data Fig 3C legend all state that tau is pooled across the 100 runs **by median** before slides are ranked. Extended Data Fig 3C was checked against the raw tau data and is genuinely median-based. But `06` read `TABLE_stable_MEAN_rank_stability.csv`, making Supp Fig 12C the only mean-based result in the paper. `05` already writes both tables, so this is a one-line correction.

### Verification (n = 24, against the real Balagan outputs)

| | before | after | paper |
|---|---|---|---|
| Fig 4D (CV score vs alpha) | r = **+**0.44 | **r = -0.4397, t22 = -2.30, P = 0.0316** | r = -0.44, t22 = -2.30, P = 0.032 |
| Supp 12C (alpha vs tau rank) | r = -0.1983, t22 = -0.95, P = 0.353 | **r = -0.1967, t22 = -0.94, P = 0.357** | legend updated to t22 = -0.94, P = 0.36 |

Conclusions are unchanged throughout. Only Supp 12C's p-value crosses a rounding boundary, 0.35 to 0.36, which is being corrected in the figure and legend on the manuscript side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
